### PR TITLE
Add game streaming compatibility API

### DIFF
--- a/api/streaming.v01.php
+++ b/api/streaming.v01.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . "/../code/autoloader.php";
+
+\Core\Database::connect();
+
+$endpoint = (new \Api\Endpoint())
+    ->params(["appid"]);
+
+$appid = $endpoint->getParam("appid");
+if (!is_numeric($appid)) {
+    (new \Api\Response())->fail();
+}
+
+$response = new \Api\Response();
+
+$select = \dibi::query("SELECT [geforce_now] FROM [streaming] WHERE [appid] = %i LIMIT 1", $appid)->fetch();
+
+if($select === null){
+    $response
+    ->data([
+        "geforce_now" => false
+    ])->respond();
+} else {
+    $response
+    ->data([
+        "geforce_now" => $select["geforce_now"] === "1"
+    ])
+    ->respond();
+}

--- a/code/ConfigTemplate.php
+++ b/code/ConfigTemplate.php
@@ -34,6 +34,7 @@ class Config {
     const SteamRepEndpoint = "[SteamRep API Server Endpoint]";
     const PCGWEndpoint = "[PCGamingWiki API Server Endpoint]";
     const SteampeekEndpoint = "[SteamPeek API Server Endpoint]";
+    const GeforceNowEndpoint = "[GeForce Now Game Listing Endpoint]";
 
     // Public facing
     const SteamLoginOpenIdHost = "[Host]";

--- a/cron/streaming.php
+++ b/cron/streaming.php
@@ -1,0 +1,52 @@
+<?php
+
+require_once __DIR__ . "/../code/autoloader.php";
+
+$db = \Core\Database::connect();
+
+$logger = Log::channel("cron");
+$logger->info("Start game streaming update");
+
+$logger->info(" -> Fetching NVIDIA GeForce Now");
+
+$apps = [];
+
+// GeForce Now
+{
+    $url = Config::GeforceNowEndpoint;
+    $result = \Core\Load::load($url);
+    $json = json_decode($result, true);
+
+    if (!is_array($json)) {
+        throw new \Exception("No data");
+    }
+
+    foreach($json as $item){
+        if(! @isset($item["steamUrl"]) || empty($item["steamUrl"])) continue;
+
+        $appid = intval(explode("/", $item["steamUrl"])[4]);
+        if($appid === 0) continue;
+
+        if(! @isset($item[$appid])) $item[$appid] = [];
+        $apps[$appid]["geforce_now"] = true;
+    }
+}
+
+// Intentionally kept this way in the event that we start tracking multiple streaming services
+$stack = new \Database\Stack(10, "streaming", [
+    "appid", "geforce_now"
+]);
+$stack->onDuplicateKeyUpdate("geforce_now");
+
+foreach($apps as $appid => $_) {
+    $stack->stack([
+        "appid" => $appid,
+        "geforce_now" => $apps[$appid]["geforce_now"]
+    ]);
+}
+
+$stack->saveStack();
+
+\dibi::query("DELETE FROM [streaming] WHERE [timestamp] < %s", date("Y-m-d H:i:s", time() - 86400));
+
+$logger->info("Finish streaming update");

--- a/enhancedsteam.sql
+++ b/enhancedsteam.sql
@@ -178,3 +178,9 @@ CREATE TABLE IF NOT EXISTS `similar` (
   `timestamp` int unsigned NOT NULL,
   PRIMARY KEY(`appid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `streaming` (
+  `appid` int NOT NULL PRIMARY KEY,
+  `geforce_now` bit NOT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Intended to be merged with a similar pull request against the extension (tfedor/AugmentedSteam#779).

`cron/streaming.php` will need to be added to `cron`.

E: keeping the endpoint a "secret" as it seems that you do that for the other endpoints listed. You can find the URL by navigating to the "find a game" page and inspecting outgoing XHRs for a static.nvidiagrid.com URL.