### PR TITLE
Add YouTube review and gameplay videos

### DIFF
--- a/api/storepagedata.v01.php
+++ b/api/storepagedata.v01.php
@@ -161,15 +161,18 @@ function GetNewYouTubeValue($the_appid) {
     }
 
 	try {
+        $reviews = NULL;
+        $gameplay = NULL;
+
 		$reviewJson = json_decode(\Core\Load::load($url.urlencode("$game \"PC\" intitle:Review")), true);
-		if ($reviewJson === null) {
+		if (is_null($reviewJson)) {
             \Log::channel("youtube")->error("Failed to decode review response for $the_appid ($game)");
         } else {
             $reviews = getDbValue($reviewJson);
         }
 
         $gameplayJson = json_decode(\Core\Load::load($url.urlencode("$game \"PC Gameplay\"")), true);
-		if ($gameplayJson === null) {
+		if (is_null($gameplayJson)) {
             \Log::channel("youtube")->error("Failed to decode gameplay response for $the_appid ($game)");
         } else {
             $gameplay = getDbValue($gameplayJson);
@@ -482,7 +485,9 @@ try {
 {
     $result = \dibi::fetch("SELECT * FROM [youtube] WHERE [appid]=%i", $appid);
 
-    if (!empty($result)) {
+    if (empty($result)) {
+        $data['youtube'] = GetNewYouTubeValue($appid);
+    } else {
         $access_time = strtotime($result['access_time']);
 
         if ($current_time - $access_time >= 60 * 60 * 24 * 7) {
@@ -494,8 +499,6 @@ try {
                 "gameplay" => $result['gameplay'],
             ];
         }
-    } else {
-        $data['youtube'] = GetNewYouTubeValue($appid);
     }
 }
 

--- a/code/ConfigTemplate.php
+++ b/code/ConfigTemplate.php
@@ -24,6 +24,7 @@ class Config {
     const SteamApiKey = "[Steam API Key]";
     const IsThereAnyDealKey = "[IsThereAnyDeal.com API Key]";
     const SteamPeekKey = "[SteamPeek API KEY]]";
+    const YouTubeKey = "[YouTube API Key]";
 
 	// Twitch
 	const TwitchClientId = "[Twitch Client Id]";

--- a/enhancedsteam.sql
+++ b/enhancedsteam.sql
@@ -185,3 +185,11 @@ CREATE TABLE IF NOT EXISTS `twitch_token` (
   INDEX(`expiry`),
   PRIMARY KEY(`token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+
+CREATE TABLE IF NOT EXISTS `youtube` (
+  `appid` int(11) NOT NULL,
+  `reviews` varchar(119) NOT NULL,
+  `gameplay` varchar(119) NOT NULL,
+  `access_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(`appid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
**Some notes**
- TTL is 7 days
- 10 gameplay and 10 review videos are fetched via the YouTube Data API
- API key needs to be retrieved from the Google Dev Console
- Quota extension form needs to be submitted, otherwise limited to 100 requests/day, so 50 store pages/day (...)

**TODO**

- Could be faster if the requests are executed asynchronously, but I didn't want to mess with the `Core` class
- Failed requests should probably get some sort of timeout, but significantly smaller than the TTL
